### PR TITLE
Support mixed types for validators

### DIFF
--- a/docs/TODO.MD
+++ b/docs/TODO.MD
@@ -18,6 +18,7 @@ Welcome to the TODO list. This is just a collection of thoughts and ideas on how
 - The ability to print out the current paths of the application.
 - A way to easily clear the route cache.
 - The new caching mechanism should support multiple caches, future iterations of the caching will offer multi cache support.
+- Support JSON arrays passed to the body and as an attribute of a class
 
 ## Resilience 
 - More Tests

--- a/docs/VALIDATORS.MD
+++ b/docs/VALIDATORS.MD
@@ -14,7 +14,7 @@ With Streetlamp comes a small selection of pre-built validators:
 | `IntValidator`        | Returns an int value                                                                                                                | Validates input is an int within the given range                                                              |
 | `RegExpValidator`     | Returns a string matching the replace criteria if set, otherwise returns input                                                      | Validates input matches the regular expression pattern given                                                  |
 
-Validators can be used along side either one of the input parameters or within data bindings.
+Validators can be used alongside either one of the input parameters or within data bindings.
 
 ## Definition
 
@@ -28,7 +28,8 @@ FilterVarsValidator(int $filter, int|array $options = 0);
     #[Method(HttpMethod::GET)]
     #[Path('/validator/{validatorId}')]
     public function simpleGetWithPathParameterAndValidator(
-        #[PathParameter('validatorId'] int $validatorId
+        #[PathParameter('validatorId'] 
+        #[MustBeDivisibleByThreeValidator] int $validatorId
     ): ResponseBuilder {
         return (new ResponseBuilder())
             ->setData($validatorId)
@@ -45,6 +46,7 @@ When implementing a custom validator if you throw any exceptions, it's essential
 Example of a custom validator:
 
 ```php
+#[Attribute(Attribute::TARGET_PARAMETER)]
 readonly class MustBeDivisibleByThreeValidator implements ValidatorInterface
 {
     public function validate(string $value): bool

--- a/src/Attributes/DataBindings/DataBindingObjectInterface.php
+++ b/src/Attributes/DataBindings/DataBindingObjectInterface.php
@@ -9,9 +9,9 @@ use stdClass;
 
 interface DataBindingObjectInterface
 {
-    public function build(ReflectionClass $class, string $data): object;
+    public function build(ReflectionClass $reflectionClass, string $data): object;
 
-    public function getObject(ReflectionClass $class, mixed $data): object;
+    public function getObject(ReflectionClass $reflectionClass, mixed $data): object;
 
     public function getSerializable(ReflectionClass $reflectionClass, object $object): mixed;
 }

--- a/src/Attributes/DataBindings/Json/JsonProperty.php
+++ b/src/Attributes/DataBindings/Json/JsonProperty.php
@@ -23,15 +23,16 @@ class JsonProperty
     public function buildProperty(object $instance, ReflectionProperty $property, mixed $jsonValue): void
     {
         $key = (empty($this->alias)) ? $property->getName() : $this->alias;
-        $value = $jsonValue->$key;
 
-        if ($this->required && empty($value)) {
+        if ($this->required && empty($jsonValue->{$key})) {
             $className = get_class($instance);
             throw new InvalidParameterTypeException(
                 "JS001",
                 "Parameter $key in $className is required, but not passed."
             );
         }
+
+        $value = $jsonValue->{$key};
 
         $attributes = $property->getAttributes();
 

--- a/src/Attributes/Parameter/BodyParameter.php
+++ b/src/Attributes/Parameter/BodyParameter.php
@@ -19,10 +19,10 @@ class BodyParameter extends Parameter
 
     /**
      * @param array $pathMatches
-     * @return string|int|bool|float
+     * @return string|int|bool|float|array
      * @throws MissingRequireBodyException
      */
-    public function value(array $pathMatches): string|int|bool|float
+    public function value(array $pathMatches): string|int|bool|float|array
     {
         $streamValue = file_get_contents($this->resourceIdentifier);
 

--- a/src/Attributes/Parameter/Parameter.php
+++ b/src/Attributes/Parameter/Parameter.php
@@ -14,10 +14,10 @@ use ReflectionClass;
 abstract class Parameter
 {
     protected string $type;
-    protected array $validators = [];
 
     public function __construct(
-        protected readonly string|null $key
+        protected readonly string|null $key,
+        protected array $validators = []
     ) {
     }
 

--- a/src/Attributes/Validators/AlphabeticValidator.php
+++ b/src/Attributes/Validators/AlphabeticValidator.php
@@ -9,12 +9,12 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class AlphabeticValidator implements ValidatorInterface
 {
-    public function validate(string $value): bool
+    public function validate(mixed $value): bool
     {
         return preg_match('/^[a-z]+$/i', $value);
     }
 
-    public function sanitize(string $value): string
+    public function sanitize(mixed $value): mixed
     {
         return $value;
     }

--- a/src/Attributes/Validators/EmailValidator.php
+++ b/src/Attributes/Validators/EmailValidator.php
@@ -9,12 +9,12 @@ use Attribute;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 class EmailValidator implements ValidatorInterface
 {
-    public function validate(string $value): bool
+    public function validate(mixed $value): bool
     {
         return filter_var($value, FILTER_VALIDATE_EMAIL);
     }
 
-    public function sanitize(string $value): string
+    public function sanitize(mixed $value): mixed
     {
         return $value;
     }

--- a/src/Attributes/Validators/FilterVarsValidator.php
+++ b/src/Attributes/Validators/FilterVarsValidator.php
@@ -15,12 +15,12 @@ readonly class FilterVarsValidator implements ValidatorInterface
     ) {
     }
 
-    public function validate(string $value): bool
+    public function validate(mixed $value): bool
     {
         return (false !== filter_var($value, $this->filter, $this->options));
     }
 
-    public function sanitize(string $value): string|int|float|bool
+    public function sanitize(mixed $value): mixed
     {
         return filter_var($value, $this->filter, $this->options);
     }

--- a/src/Attributes/Validators/FloatValidator.php
+++ b/src/Attributes/Validators/FloatValidator.php
@@ -13,12 +13,12 @@ readonly class FloatValidator implements ValidatorInterface
     {
     }
 
-    public function validate(string $value): bool
+    public function validate(mixed $value): bool
     {
         return (floatval($value) == $value) && $value <= $this->max && $value >= $this->min;
     }
 
-    public function sanitize(string $value): float
+    public function sanitize(mixed $value): float
     {
         return (float) $value;
     }

--- a/src/Attributes/Validators/IntValidator.php
+++ b/src/Attributes/Validators/IntValidator.php
@@ -13,12 +13,12 @@ readonly class IntValidator implements ValidatorInterface
     {
     }
 
-    public function validate(string $value): bool
+    public function validate(mixed $value): bool
     {
         return (intval($value) == $value) && $value <= $this->max && $value >= $this->min;
     }
 
-    public function sanitize(string $value): int
+    public function sanitize(mixed $value): int
     {
         return (int) $value;
     }

--- a/src/Attributes/Validators/RegExpValidator.php
+++ b/src/Attributes/Validators/RegExpValidator.php
@@ -13,12 +13,12 @@ readonly class RegExpValidator implements ValidatorInterface
     {
     }
 
-    public function validate(string $value): bool
+    public function validate(mixed $value): bool
     {
         return preg_match($this->pattern, $value);
     }
 
-    public function sanitize(string $value): string
+    public function sanitize(mixed $value): mixed
     {
         if (!$this->replace) {
             return $value;

--- a/src/Attributes/Validators/ValidatorInterface.php
+++ b/src/Attributes/Validators/ValidatorInterface.php
@@ -6,6 +6,6 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 interface ValidatorInterface
 {
-    public function validate(string $value): bool;
-    public function sanitize(string $value): string|int|float|bool;
+    public function validate(mixed $value): bool;
+    public function sanitize(mixed $value): mixed;
 }

--- a/tests/RouterTest.php
+++ b/tests/RouterTest.php
@@ -5,11 +5,33 @@ declare(strict_types=1);
 namespace willitscale\StreetlampTests;
 
 use willitscale\Streetlamp\Enums\MediaType;
+use willitscale\Streetlamp\Exceptions\InvalidParameterTypeException;
+use willitscale\Streetlamp\Exceptions\Validators\InvalidParameterFailedToPassFilterValidation;
 use willitscale\StreetlampTest\RouteTestCase;
+use function PHPUnit\Framework\assertEquals;
 
 class RouterTest extends RouteTestCase
 {
+    const TEST_BODY_FILE = __DIR__ . DIRECTORY_SEPARATOR . 'TestApp' . DIRECTORY_SEPARATOR . 'test.dat';
     const COMPOSER_TEST_FILE = __DIR__ . DIRECTORY_SEPARATOR . 'TestApp' . DIRECTORY_SEPARATOR . 'composer.test.json';
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        if (file_exists(self::TEST_BODY_FILE)) {
+            unlink(self::TEST_BODY_FILE);
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if (file_exists(self::TEST_BODY_FILE)) {
+            unlink(self::TEST_BODY_FILE);
+        }
+    }
 
     public function testRouterGetMethodWithNoParameters(): void
     {
@@ -172,5 +194,101 @@ class RouterTest extends RouteTestCase
         $response = $router->route(true);
 
         $this->assertEquals($secondCachedValue, $response);
+    }
+
+    public function testRouterDataMappingCorrectlyCreatesAnObject(): void
+    {
+        $testData = [
+            'name' => 'Test',
+            'age' => 123
+        ];
+
+        file_put_contents(self::TEST_BODY_FILE, json_encode($testData));
+
+        $router = $this->setupRouter(
+            'POST',
+            '/data/validation',
+            MediaType::APPLICATION_JSON->value,
+            __DIR__,
+            self::COMPOSER_TEST_FILE
+        );
+
+        $response = $router->route(true);
+
+        assertEquals($testData, json_decode($response, true));
+    }
+
+    public function testRouterDataMappingWithIncorrectDataFailsToCreateObject(): void
+    {
+        $testData = [
+            'name' => 'Test'
+        ];
+
+        $testFile =
+            file_put_contents(self::TEST_BODY_FILE, json_encode($testData));
+
+        $router = $this->setupRouter(
+            'POST',
+            '/data/validation',
+            MediaType::APPLICATION_JSON->value,
+            __DIR__,
+            self::COMPOSER_TEST_FILE
+        );
+
+        $this->expectException(InvalidParameterTypeException::class);
+        $router->route(true);
+    }
+
+    public function testRouterDataMappingCorrectlyCreatesAnArrayOfObjects(): void
+    {
+        $testData = [
+            [
+                'name' => 'Test',
+                'age' => 123
+            ],
+            [
+                'name' => 'Tester',
+                'age' => 456
+            ]
+        ];
+
+        file_put_contents(self::TEST_BODY_FILE, json_encode($testData));
+
+        $router = $this->setupRouter(
+            'POST',
+            '/data/validations',
+            MediaType::APPLICATION_JSON->value,
+            __DIR__,
+            self::COMPOSER_TEST_FILE
+        );
+
+        $response = $router->route(true);
+        assertEquals($testData, json_decode($response, true));
+    }
+
+    public function testRouterDataMappingWithIncorrectDataFailsToCreateAnArrayOfObjects(): void
+    {
+        $testData = [
+            [
+                'name' => 'Test',
+                'age' => 123
+            ],
+            [
+                'name' => 'Tester'
+            ]
+        ];
+
+        file_put_contents(self::TEST_BODY_FILE, json_encode($testData));
+
+        $router = $this->setupRouter(
+            'POST',
+            '/data/validations',
+            MediaType::APPLICATION_JSON->value,
+            __DIR__,
+            self::COMPOSER_TEST_FILE
+        );
+
+        $this->expectException(InvalidParameterFailedToPassFilterValidation::class);
+        $router->route(true);
     }
 }

--- a/tests/TestApp/DataType.php
+++ b/tests/TestApp/DataType.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace willitscale\StreetlampTests\TestApp;
+
+use JsonSerializable;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonObject;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonProperty;
+
+#[JsonObject]
+class DataType implements JsonSerializable
+{
+    public function __construct(
+        #[JsonProperty(true)] private string $name,
+        #[JsonProperty(true)] private int $age
+    ) {}
+
+    public function jsonSerialize(): mixed {
+        return (object) get_object_vars($this);
+    }
+}

--- a/tests/TestApp/DataValidator.php
+++ b/tests/TestApp/DataValidator.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace willitscale\StreetlampTests\TestApp;
+
+use Attribute;
+use willitscale\Streetlamp\Attributes\Validators\ValidatorInterface;
+
+#[Attribute]
+class DataValidator implements ValidatorInterface
+{
+    public function validate(mixed $value): bool
+    {
+        $value = json_decode($value);
+
+        if (!is_array($value)) {
+            return false;
+        }
+
+        foreach($value as $object) {
+            if (!isset($object->name) || !isset($object->age)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    public function sanitize(mixed $value): mixed
+    {
+        $value = json_decode($value);
+
+        foreach($value as &$object) {
+            $object = new DataType($object->name, $object->age);
+        }
+
+        return $value;
+    }
+}

--- a/tests/TestApp/TestController.php
+++ b/tests/TestApp/TestController.php
@@ -7,6 +7,8 @@ namespace willitscale\StreetlampTests\TestApp;
 use willitscale\Streetlamp\Attributes\Accepts;
 use willitscale\Streetlamp\Attributes\Cache\Cache;
 use willitscale\Streetlamp\Attributes\Controller\RouteController;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonProperty;
+use willitscale\Streetlamp\Attributes\Parameter\BodyParameter;
 use willitscale\Streetlamp\Attributes\Parameter\HeaderParameter;
 use willitscale\Streetlamp\Attributes\Parameter\PathParameter;
 use willitscale\Streetlamp\Attributes\Parameter\PostParameter;
@@ -113,6 +115,28 @@ class TestController
     ): ResponseBuilder {
         return (new ResponseBuilder())
             ->setData($cacheId)
+            ->setContentType(MediaType::APPLICATION_JSON)
+            ->setHttpStatusCode(HttpStatusCode::HTTP_OK);
+    }
+
+    #[Method(HttpMethod::POST)]
+    #[Path('/data/validation')]
+    public function validateSingleInput(
+        #[BodyParameter([], __DIR__ . DIRECTORY_SEPARATOR . 'test.dat')] DataType $dataType
+    ): ResponseBuilder {
+        return (new ResponseBuilder())
+            ->setData($dataType)
+            ->setContentType(MediaType::APPLICATION_JSON)
+            ->setHttpStatusCode(HttpStatusCode::HTTP_OK);
+    }
+
+    #[Method(HttpMethod::POST)]
+    #[Path('/data/validations')]
+    public function validateMultipleInputs(
+        #[BodyParameter([new DataValidator()], __DIR__ . DIRECTORY_SEPARATOR . 'test.dat')] array $dataTypes
+    ): ResponseBuilder {
+        return (new ResponseBuilder())
+            ->setData($dataTypes)
             ->setContentType(MediaType::APPLICATION_JSON)
             ->setHttpStatusCode(HttpStatusCode::HTTP_OK);
     }


### PR DESCRIPTION
Changes:
- Allow arrays to be received as a body parameter
- All validators expect mixed input/output instead of just string
- More supporting tests for validators and data mapping
- Fixed documentation on validators

Fixes:
- When missing a JSON attribute throw exception not fatal error
- Correctly passing the validators from the parameters