### PR TITLE
Fixed the Data Mapping Json Object response

### DIFF
--- a/src/Attributes/DataBindings/Json/JsonMatchesType.php
+++ b/src/Attributes/DataBindings/Json/JsonMatchesType.php
@@ -15,7 +15,7 @@ trait JsonMatchesType
             ('float' === $type->getName() && is_float($value)) ||
             ('bool' === $type->getName() && is_bool($value)) ||
             ('string' === $type->getName() && is_string($value)) ||
-            ('null' === $type->getName() && is_null($value)) ||
+            (('null' === $type->getName() || $type->allowsNull()) && is_null($value)) ||
             ('object' === gettype($value) &&
                 ($type->getName() === get_class($value) || $type->getName() === gettype($value)));
     }

--- a/src/Attributes/DataBindings/Json/JsonMatchesType.php
+++ b/src/Attributes/DataBindings/Json/JsonMatchesType.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Attributes\DataBindings\Json;
+
+use ReflectionType;
+
+trait JsonMatchesType
+{
+    private function matchesType(ReflectionType $type, mixed $value): bool
+    {
+        return ('array' === $type->getName() && is_array($value)) ||
+            ('int' === $type->getName() && is_int($value)) ||
+            ('float' === $type->getName() && is_float($value)) ||
+            ('bool' === $type->getName() && is_bool($value)) ||
+            ('string' === $type->getName() && is_string($value)) ||
+            ('null' === $type->getName() && is_null($value)) ||
+            ('object' === gettype($value) &&
+                ($type->getName() === get_class($value) || $type->getName() === gettype($value)));
+    }
+}

--- a/src/Attributes/DataBindings/Json/JsonProperty.php
+++ b/src/Attributes/DataBindings/Json/JsonProperty.php
@@ -18,6 +18,8 @@ use ReflectionType;
 #[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
 readonly class JsonProperty implements JsonAttribute
 {
+    use JsonMatchesType;
+
     public function __construct(
         private bool $required = true,
         private ?string $alias = null
@@ -36,11 +38,7 @@ readonly class JsonProperty implements JsonAttribute
             );
         }
 
-        if (!isset($jsonValue->{$key})) {
-            return;
-        }
-
-        $value = $jsonValue->{$key};
+        $value = $jsonValue->{$key} ?? null;
 
         $attributes = $property->getAttributes();
 
@@ -82,7 +80,6 @@ readonly class JsonProperty implements JsonAttribute
         }
 
         if (!$typeMatches) {
-            dd($key, $value, gettype($value), get_class($value), array_map(fn($type)=>$type->getName(), $types));
             $className = get_class($instance);
             $valueType = gettype($value);
             $propertyName = $property->getType() instanceof ReflectionNamedType
@@ -101,16 +98,5 @@ readonly class JsonProperty implements JsonAttribute
     public function getAlias(): ?string
     {
         return $this->alias;
-    }
-
-    private function matchesType(ReflectionType $type, mixed $value): bool
-    {
-        return ('array' === $type->getName() && is_array($value)) ||
-            ('int' === $type->getName() && is_int($value)) ||
-            ('float' === $type->getName() && is_float($value)) ||
-            ('bool' === $type->getName() && is_bool($value)) ||
-            ('string' === $type->getName() && is_string($value)) ||
-            ('object' === gettype($value) &&
-                ($type->getName() === get_class($value) || $type->getName() === gettype($value)));
     }
 }


### PR DESCRIPTION
In line with the JsonProperty request fix, this patch fixes the JsonObject response to also handle multi type responses. It also contains a fix to handle null parameters.