### PR TITLE
Support for SSE and JsonRPC

### DIFF
--- a/docs/Attributes/RESPONSE_TYPE.MD
+++ b/docs/Attributes/RESPONSE_TYPE.MD
@@ -1,0 +1,41 @@
+# Response Type
+
+Specify the response type for the route. This was built specifically for the `ServerSideEvents` response type, the default mechanism is `HttpMessage`.
+
+## Definition
+```php
+#[ResponseType(?string $responseType = null)]
+```
+
+- `$responseType` class and namespace of the response type which is currently only `ServerSideEvents` or `HttpMessage` (default).
+
+## Targets
+
+- `Attribute::TARGET_CLASS`
+- `Attribute::TARGET_METHOD`
+
+## Example
+
+Code:
+```php
+    #[Method(HttpMethod::GET)]
+    #[Path('/sse')]
+    #[ResponseType(ServerSideEvents::class)]
+    public function sse(
+        ServerSideEvents $serverSideEvents
+    ): void {
+        $serverSideEvents
+            ->setEventDelay(ServerSideEvents::SECOND_IN_MICROSECONDS)
+            ->dispatch([
+                new Id('123'),
+                new Event('ping'),
+                new Data(new TestModel("Test", "test@example.com", new AgeModel(12)))
+            ]);
+    }
+```
+
+cURL:
+```shell
+curl --request POST \ 
+    --location 'http://localhost/sse'
+```

--- a/docs/ROUTING_ATTRIBUTES.MD
+++ b/docs/ROUTING_ATTRIBUTES.MD
@@ -3,12 +3,14 @@
 Routing attributes are used by the `RouteBuilder` to build routes.
 There's a number of different attribute variations you can use between classes and methods.
 
-The following table lists the routing attributes and where they can be used, more detailed descriptions and examples are below.
+The following table lists the routing attributes and where they can be used, more detailed descriptions and examples are
+below.
 
-| Attribute                                         | Type         | Description                            |
-|---------------------------------------------------|--------------|----------------------------------------|
-| [RouteController](Attributes/ROUTE_CONTROLLER.MD) | Class        | Instruct a class to be a controller    |
-| [Accepts](Attributes/ACCEPTS.MD)                  | Class/Method | Specify the accepted content type      |
-| [Path](Attributes/PATH.MD)                        | Class/Method | Specify the URL path                   |
-| [Middleware](Attributes/MIDDLEWARE.MD)           | Class/Method | Bind a middleware operation            |
-| [Method](Attributes/METHOD.MD)                    | Method       | Specify the HTTP method for that route |
+| Attribute                                         | Type         | Description                              |
+|---------------------------------------------------|--------------|------------------------------------------|
+| [RouteController](Attributes/ROUTE_CONTROLLER.MD) | Class        | Instruct a class to be a controller      |
+| [Accepts](Attributes/ACCEPTS.MD)                  | Class/Method | Specify the accepted content type        |
+| [Path](Attributes/PATH.MD)                        | Class/Method | Specify the URL path                     |
+| [Middleware](Attributes/MIDDLEWARE.MD)            | Class/Method | Bind a middleware operation              |
+| [Method](Attributes/METHOD.MD)                    | Method       | Specify the HTTP method for that route   |
+| [ResponseType](Attributes/RESPONSE_TYPE.MD)       | Method       | Specify the response type for that route |

--- a/src/Attributes/ResponseType.php
+++ b/src/Attributes/ResponseType.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace willitscale\Streetlamp\Attributes;
+
+use Attribute;
+use willitscale\Streetlamp\Models\Controller;
+use willitscale\Streetlamp\Models\Route;
+
+#[Attribute(Attribute::TARGET_CLASS | Attribute::TARGET_METHOD)]
+readonly class ResponseType implements AttributeContract
+{
+    public function __construct(
+        private ?string $responseType = null
+    ) {
+    }
+
+    public function applyToController(Controller $controller): void
+    {
+        $controller->setResponseType($this->responseType);
+    }
+
+    public function applyToRoute(Route $route): void
+    {
+        $route->setResponseType($this->responseType);
+    }
+}

--- a/src/Attributes/Validators/AlphabeticValidator.php
+++ b/src/Attributes/Validators/AlphabeticValidator.php
@@ -6,7 +6,7 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 class AlphabeticValidator implements ValidatorInterface
 {
     public function validate(mixed $value): bool

--- a/src/Attributes/Validators/EmailValidator.php
+++ b/src/Attributes/Validators/EmailValidator.php
@@ -6,7 +6,7 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 class EmailValidator implements ValidatorInterface
 {
     public function validate(mixed $value): bool

--- a/src/Attributes/Validators/FilterVarsValidator.php
+++ b/src/Attributes/Validators/FilterVarsValidator.php
@@ -6,7 +6,7 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 readonly class FilterVarsValidator implements ValidatorInterface
 {
     public function __construct(

--- a/src/Attributes/Validators/FloatValidator.php
+++ b/src/Attributes/Validators/FloatValidator.php
@@ -6,7 +6,7 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 readonly class FloatValidator implements ValidatorInterface
 {
     public function __construct(

--- a/src/Attributes/Validators/IntValidator.php
+++ b/src/Attributes/Validators/IntValidator.php
@@ -6,7 +6,7 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 readonly class IntValidator implements ValidatorInterface
 {
     public function __construct(

--- a/src/Attributes/Validators/RegExpValidator.php
+++ b/src/Attributes/Validators/RegExpValidator.php
@@ -6,7 +6,7 @@ namespace willitscale\Streetlamp\Attributes\Validators;
 
 use Attribute;
 
-#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER)]
+#[Attribute(Attribute::TARGET_PROPERTY | Attribute::TARGET_PARAMETER | Attribute::IS_REPEATABLE)]
 readonly class RegExpValidator implements ValidatorInterface
 {
     public function __construct(

--- a/src/Models/Context.php
+++ b/src/Models/Context.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace willitscale\Streetlamp\Models;
 
 use willitscale\Streetlamp\Enums\MediaType;
+use willitscale\Streetlamp\ResponseTypes\HttpMessage;
 
 abstract class Context
 {
@@ -12,7 +13,8 @@ abstract class Context
         protected string $class,
         protected string|null $path = null,
         protected string|null $accepts = null,
-        protected array $middleware = []
+        protected array $middleware = [],
+        private ?string $responseType = null
     ) {
     }
 
@@ -81,5 +83,16 @@ abstract class Context
     public function popMiddleware(): string
     {
         return array_shift($this->middleware);
+    }
+
+    public function setResponseType(?string $responseType): self
+    {
+        $this->responseType = $responseType;
+        return $this;
+    }
+
+    public function getResponseType(): string
+    {
+        return $this->responseType ?? HttpMessage::class;
     }
 }

--- a/src/Models/Controller.php
+++ b/src/Models/Controller.php
@@ -12,9 +12,10 @@ class Controller extends Context
         string|null $path = '',
         string|null $accepts = null,
         private bool $isController = false,
-        array $middleware = []
+        array $middleware = [],
+        ?string $responseType = null
     ) {
-        parent::__construct($class, $path, $accepts, $middleware);
+        parent::__construct($class, $path, $accepts, $middleware, $responseType);
     }
 
     /**

--- a/src/Models/JsonRpc/Error.php
+++ b/src/Models/JsonRpc/Error.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\JsonRpc;
+
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonIgnore;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonObject;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonProperty;
+
+#[JsonObject]
+readonly class Error
+{
+    public function __construct(
+        #[JsonProperty] int $code,
+        #[JsonProperty] string $message,
+        #[JsonProperty(false)] #[JsonIgnore(true)] mixed $data = null
+    ) {
+    }
+}

--- a/src/Models/JsonRpc/Notification.php
+++ b/src/Models/JsonRpc/Notification.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\JsonRpc;
+
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonObject;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonProperty;
+
+#[JsonObject]
+readonly class Notification
+{
+    public function __construct(
+        #[JsonProperty] private string $jsonrpc,
+        #[JsonProperty] private string $method,
+        #[JsonProperty(false)] private array|object|null $params = null,
+    ) {
+    }
+}

--- a/src/Models/JsonRpc/Request.php
+++ b/src/Models/JsonRpc/Request.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\JsonRpc;
+
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonObject;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonProperty;
+use willitscale\Streetlamp\Attributes\Validators\RegExpValidator;
+
+#[JsonObject]
+readonly class Request
+{
+    public function __construct(
+        #[JsonProperty] #[RegExpValidator("/2\.0/")] private string $jsonrpc,
+        #[JsonProperty] private string|int $id,
+        #[JsonProperty] private string $method,
+        #[JsonProperty(false)] private array|object|null $params = null
+    ) {
+    }
+
+    public function getJsonRpc(): string
+    {
+        return $this->jsonrpc;
+    }
+
+    public function getId(): int|string
+    {
+        return $this->id;
+    }
+
+    public function getMethod(): string
+    {
+        return $this->method;
+    }
+
+    public function getParams(): array|object|null
+    {
+        return $this->params;
+    }
+}

--- a/src/Models/JsonRpc/Response.php
+++ b/src/Models/JsonRpc/Response.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\JsonRpc;
+
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonIgnore;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonObject;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonProperty;
+
+#[JsonObject]
+readonly class Response
+{
+    public function __construct(
+        #[JsonProperty] private string $jsonrpc,
+        #[JsonProperty] private string|int $id,
+        #[JsonProperty(false)] #[JsonIgnore(true)] private array|object|null $result,
+        #[JsonProperty(false)] #[JsonIgnore(true)] private ?Error $error,
+    ) {
+    }
+
+    public function getJsonrpc(): string
+    {
+        return $this->jsonrpc;
+    }
+
+    public function getId(): int|string
+    {
+        return $this->id;
+    }
+
+    public function getResult(): array|object|null
+    {
+        return $this->result;
+    }
+
+    public function getError(): ?Error
+    {
+        return $this->error;
+    }
+}

--- a/src/Models/Route.php
+++ b/src/Models/Route.php
@@ -20,9 +20,10 @@ class Route extends Context
         string|null $accepts = null,
         private array $parameters = [],
         array $middleware = [],
+        ?string $responseType = null,
         private CacheRule|null $cacheRule = null
     ) {
-        parent::__construct($class, $path, $accepts, $middleware);
+        parent::__construct($class, $path, $accepts, $middleware, $responseType);
     }
 
     public function getCacheRule(): ?CacheRule

--- a/src/Models/ServerSideEvents/Data.php
+++ b/src/Models/ServerSideEvents/Data.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\ServerSideEvents;
+
+use ReflectionClass;
+use willitscale\Streetlamp\Attributes\DataBindings\DataBindingObjectInterface;
+use willitscale\Streetlamp\Attributes\DataBindings\Json\JsonObject;
+
+class Data implements ServerSideEvent
+{
+    public function __construct(
+        public string|object $data
+    ) {
+    }
+
+    public function dispatch(): string
+    {
+        if (is_object($this->data)) {
+            $reflectionClass = new ReflectionClass($this->data);
+            $reflectionAttributes = $reflectionClass->getAttributes(JsonObject::class);
+
+            foreach ($reflectionAttributes as $attribute) {
+                $attributeInstance = $attribute->newInstance();
+                if ($attributeInstance instanceof DataBindingObjectInterface) {
+                    $serialized = $attributeInstance->getSerializable($reflectionClass, $this->data);
+                    $this->data = json_encode($serialized, JSON_THROW_ON_ERROR);
+                }
+            }
+        }
+
+        return "data: {$this->data}";
+    }
+}

--- a/src/Models/ServerSideEvents/Event.php
+++ b/src/Models/ServerSideEvents/Event.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\ServerSideEvents;
+
+class Event implements ServerSideEvent
+{
+    public function __construct(
+        public string $event
+    ) {
+    }
+
+    public function dispatch(): string
+    {
+        return "event: {$this->event}";
+    }
+}

--- a/src/Models/ServerSideEvents/Id.php
+++ b/src/Models/ServerSideEvents/Id.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\ServerSideEvents;
+
+class Id implements ServerSideEvent
+{
+    public function __construct(
+        public string|int $id
+    ) {
+    }
+
+    public function dispatch(): string
+    {
+        return "id: {$this->id}";
+    }
+}

--- a/src/Models/ServerSideEvents/Retry.php
+++ b/src/Models/ServerSideEvents/Retry.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\ServerSideEvents;
+
+class Retry implements ServerSideEvent
+{
+    public function __construct(
+        public int $intervalInMilliseconds
+    ) {
+    }
+
+    public function dispatch(): string
+    {
+        echo "retry: {$this->intervalInMilliseconds}";
+    }
+}

--- a/src/Models/ServerSideEvents/ServerSideEvent.php
+++ b/src/Models/ServerSideEvents/ServerSideEvent.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\Models\ServerSideEvents;
+
+interface ServerSideEvent
+{
+    public function dispatch(): string;
+}

--- a/src/ResponseTypes/HttpMessage.php
+++ b/src/ResponseTypes/HttpMessage.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\ResponseTypes;
+
+use DI\Container;
+use Exception;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use willitscale\Streetlamp\Exceptions\InvalidRouteResponseException;
+use willitscale\Streetlamp\Models\Route;
+use willitscale\Streetlamp\Requests\Stream;
+use willitscale\Streetlamp\RouteBuilder;
+
+readonly class HttpMessage implements ResponseTypeInterface
+{
+    public function __construct(
+        private RouteBuilder $routeBuilder,
+        private Container $container,
+        private LoggerInterface $logger,
+    ) {
+    }
+
+    public function execute(
+        Route $route,
+        ServerRequestInterface $request,
+        array $args,
+    ): ResponseInterface {
+        try {
+            return $this->restoreResponse($route, $args);
+        } catch (Throwable $e) {
+            $this->logger->info('Response is not in cache: ' . $e->getMessage());
+        }
+
+        $requestArgument = [
+            'request' => $request
+        ];
+
+        $application = $this->container->make(
+            $route->getClass(),
+            $requestArgument
+        );
+
+        $response = $this->container->call(
+            [
+                $application,
+                $route->getFunction()
+            ],
+            array_merge($requestArgument, $args)
+        );
+
+        if (!isset($response) || !($response instanceof ResponseInterface)) {
+            unset($response);
+            throw new InvalidRouteResponseException(
+                'R001',
+                'Call to ' . $route->getClass() . '::' .
+                $route->getFunction() . ' did not return a Response object.'
+            );
+        }
+
+        try {
+            $this->storeResponse($route, $args, $response);
+        } catch (Throwable $e) {
+            $this->logger->error('Failed to cache response: ' . $e->getMessage());
+        }
+
+        return $response;
+    }
+
+    private function restoreResponse(
+        Route $route,
+        array $args
+    ): ResponseInterface {
+        $cacheRule = $route->getCacheRule();
+
+        if (is_null($cacheRule)) {
+            // TODO: this should be a custom exception
+            throw new Exception('No cache rule enabled');
+        }
+
+        $cacheHandler = $this->routeBuilder->getRouterConfig()->getCacheHandler();
+
+        $key = $cacheRule->getKey($route, $args);
+
+        if (!$cacheHandler->has($key)) {
+            // TODO: this should be a custom exception
+            throw new Exception('Cache key does not exist: ' . $key);
+        }
+
+        $data = $cacheHandler->get($key);
+
+        // Instance of check here
+        if (!isset($data['response']) || !($data['response'] instanceof ResponseInterface)) {
+            unset($data['response']);
+            throw new InvalidRouteResponseException(
+                'R004',
+                'Cached response for key ' . $key . ' is not a valid Response object.'
+            );
+        }
+
+        $stream = new Stream('php://temp', 'rw+');
+        $stream->write($data['contents']);
+
+        return $data['response']->withBody($stream);
+    }
+
+    private function storeResponse(
+        Route $route,
+        array $args,
+        ResponseInterface $response
+    ): void {
+        $cacheRule = $route->getCacheRule();
+
+        if (is_null($cacheRule)) {
+            // TODO: this should be a custom exception
+            throw new Exception('No cache rule enabled');
+        }
+
+        $cacheHandler = $this->routeBuilder->getRouterConfig()->getCacheHandler();
+
+        $key = $cacheRule->getKey($route, $args);
+        $ttl = $cacheRule->getCacheTtl();
+
+        $data = [
+            'response' => $response,
+            'contents' => $response->getBody()->getContents(),
+        ];
+
+        $cacheHandler->set($key, $data, $ttl);
+    }
+}

--- a/src/ResponseTypes/ResponseTypeInterface.php
+++ b/src/ResponseTypes/ResponseTypeInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\ResponseTypes;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use willitscale\Streetlamp\Models\Route;
+
+interface ResponseTypeInterface
+{
+    public function execute(
+        Route $route,
+        ServerRequestInterface $request,
+        array $args,
+    ): ResponseInterface;
+}

--- a/src/ResponseTypes/ServerSideEvents.php
+++ b/src/ResponseTypes/ServerSideEvents.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace willitscale\Streetlamp\ResponseTypes;
+
+use DI\Container;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use willitscale\Streetlamp\Models\Route;
+use willitscale\Streetlamp\Models\ServerSideEvents\ServerSideEvent;
+use willitscale\Streetlamp\Requests\Stream;
+use willitscale\Streetlamp\Responses\Response;
+
+class ServerSideEvents implements ResponseTypeInterface
+{
+    public const int SECOND_IN_MICROSECONDS = 1000000;
+
+    private int $eventDelayMicroseconds = 0;
+
+    public function __construct(
+        private readonly Container $container,
+    ) {
+    }
+
+    public function execute(Route $route, ServerRequestInterface $request, array $args): ResponseInterface
+    {
+        $requestArgument = [
+            'request' => $request,
+            'serverSideEvents' => $this,
+        ];
+
+        $application = $this->container->make(
+            $route->getClass(),
+            $requestArgument
+        );
+
+        header("X-Accel-Buffering: no");
+        header("Content-Type: text/event-stream");
+        header("Cache-Control: no-cache");
+
+        while (true) {
+            $this->container->call(
+                [
+                    $application,
+                    $route->getFunction()
+                ],
+                array_merge($requestArgument, $args)
+            );
+
+            if (connection_aborted()) {
+                break;
+            }
+
+            if (self::SECOND_IN_MICROSECONDS > $this->eventDelayMicroseconds) {
+                sleep($this->eventDelayMicroseconds / self::SECOND_IN_MICROSECONDS);
+            } else {
+                usleep($this->eventDelayMicroseconds);
+            }
+        }
+
+        return new Response(new Stream('php://temp', 'r+'));
+    }
+
+    public function setEventDelay(int $microseconds): self
+    {
+        $this->eventDelayMicroseconds = $microseconds;
+        return $this;
+    }
+
+    public function dispatch(array $events): self
+    {
+        foreach ($events as $event) {
+            if (!$event instanceof ServerSideEvent) {
+                throw new \InvalidArgumentException(
+                    'All events must implement the ServerSideEvent interface.'
+                );
+            }
+
+            echo $event->dispatch(), PHP_EOL, PHP_EOL;
+        }
+
+        if (ob_get_contents()) {
+            ob_end_flush();
+        }
+
+        flush();
+
+        return $this;
+    }
+}

--- a/src/Router.php
+++ b/src/Router.php
@@ -24,6 +24,9 @@ readonly class Router
         private Container $container = new Container(),
         private LoggerInterface $logger = new NullLogger()
     ) {
+        $this->container->set(RouteBuilder::class, $routeBuilder);
+        $this->container->set(Container::class, $container);
+        $this->container->set(LoggerInterface::class, $logger);
     }
 
     public function route(): ResponseInterface
@@ -46,12 +49,12 @@ readonly class Router
                     continue;
                 }
 
-                $responseHandler = new ResponseHandler(
-                    $route,
-                    $this->routeBuilder,
-                    $this->container,
-                    $this->logger,
-                    $matches
+                $responseHandler = $this->container->make(
+                    ResponseHandler::class,
+                    [
+                        'route' => $route,
+                        'matches' => $matches
+                    ]
                 );
 
                 return $responseHandler->handle($request);


### PR DESCRIPTION
Added:
- ResponseTypes, this is primarily to support SSE along side HTTP messages
- JsonRPC models
- Server Side Events implemented
- ResponseType documentation added

TODO:
- Improved SSE documentation
  - configuration for Apache/Nginx timeouts, disabling buffering, etc
  - Better documentation and explanation on how to use ServerSideEvents
- Tests around the SSE implementation