### PR TITLE
Aligning header keys with RFC-9110 section 5.1

### DIFF
--- a/src/Requests/ServerRequest.php
+++ b/src/Requests/ServerRequest.php
@@ -47,6 +47,10 @@ class ServerRequest implements ServerRequestInterface
         $this->uploadedFiles = $uploadedFiles ?? $_FILES;
         $this->parsedBody = $parsedBody ?? $_POST;
         $this->attributes = $attributes;
+
+        foreach ($this->headers as $name => $values) {
+            $this->headers[strtolower($name)] = $values;
+        }
     }
 
     public function extractHeadersFromServer(): array
@@ -54,10 +58,7 @@ class ServerRequest implements ServerRequestInterface
         $headers = [];
         foreach ($_SERVER as $name => $value) {
             if (0 === stripos($name, 'HTTP_')) {
-                // The only issue with this is that if a header contains underscores, they will be
-                // replaced with dashes and lowercase first letter will be replaced with uppercase.
-                $key = ucwords(str_replace('_', ' ', strtolower(substr($name, 5))));
-                $key = str_replace(' ', '-', $key);
+                $key = substr($name, 5);
                 $headers[$key] = [$value];
             }
         }
@@ -149,6 +150,8 @@ class ServerRequest implements ServerRequestInterface
 
     public function getHeaderLine($name): string
     {
+        $name = strtolower($name);
+
         if (empty($this->headers[$name])) {
             return '';
         }

--- a/tests/Controllers/HeadersControllerTest.php
+++ b/tests/Controllers/HeadersControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+namespace willitscale\StreetlampTests\Controllers;
+
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+class HeadersControllerTest extends ControllerTestCase
+{
+    #[Test]
+    #[DataProvider('headersDataProvider')]
+    public function itShouldReturnLowerCaseHeaderValue(
+        string $value,
+        string $key,
+        string $path
+    ): void {
+        $router = $this->setupRouter(
+            'GET',
+            $path,
+            $this->getTestRoot(),
+            $this->getComposerTestFile(),
+            null,
+            [$key => $value]
+        );
+
+        $response = $router->route()->getBody()->getContents();
+        $this->assertEquals($value, $response);
+    }
+
+    public static function headersDataProvider(): array
+    {
+        return [
+            'it should pass a lower case header with a lower case key' => [
+                'value' => 'test',
+                'key' => 'lower-case',
+                'path' => '/headers/lower-case'
+            ],
+            'it should pass a lower case header with an upper case key' => [
+                'value' => 'test',
+                'key' => 'LOWER-CASE',
+                'path' => '/headers/lower-case'
+            ],
+            'it should pass a lower case header with a mixed case key' => [
+                'value' => 'test',
+                'key' => 'LoWeR-cAsE',
+                'path' => '/headers/lower-case'
+            ],
+            'it should pass a lower case header with a camel case key' => [
+                'value' => 'test',
+                'key' => 'Lower-Case',
+                'path' => '/headers/lower-case'
+            ],
+            'it should pass a upper case header with an upper case key' => [
+                'value' => 'test',
+                'key' => 'UPPER-CASE',
+                'path' => '/headers/upper-case'
+            ],
+            'it should pass a upper case header with a lower case key' => [
+                'value' => 'test',
+                'key' => 'upper-case',
+                'path' => '/headers/upper-case'
+            ],
+            'it should pass a upper case header with a mixed case key' => [
+                'value' => 'test',
+                'key' => 'UpPeR-cAsE',
+                'path' => '/headers/upper-case'
+            ],
+            'it should pass a upper case header with a camel case key' => [
+                'value' => 'test',
+                'key' => 'Upper-Case',
+                'path' => '/headers/upper-case'
+            ],
+            'it should pass a mixed case header with an upper case key' => [
+                'value' => 'test',
+                'key' => 'MIXED-CASE',
+                'path' => '/headers/mixed-case'
+            ],
+            'it should pass a mixed case header with a lower case key' => [
+                'value' => 'test',
+                'key' => 'mixed-case',
+                'path' => '/headers/mixed-case'
+            ],
+            'it should pass a mixed case header with a mixed case key' => [
+                'value' => 'test',
+                'key' => 'MiXeD-cAsE',
+                'path' => '/headers/mixed-case'
+            ],
+            'it should pass a mixed case header with a camel case key' => [
+                'value' => 'test',
+                'key' => 'Mixed-Case',
+                'path' => '/headers/mixed-case'
+            ],
+            'it should pass a camel case header with an upper case key' => [
+                'value' => 'test',
+                'key' => 'CAMEL-CASE',
+                'path' => '/headers/camel-case'
+            ],
+            'it should pass a camel case header with a lower case key' => [
+                'value' => 'test',
+                'key' => 'camel-case',
+                'path' => '/headers/camel-case'
+            ],
+            'it should pass a camel case header with a mixed case key' => [
+                'value' => 'test',
+                'key' => 'CaMeL-cAsE',
+                'path' => '/headers/camel-case'
+            ],
+            'it should pass a camel case header with a camel case key' => [
+                'value' => 'test',
+                'key' => 'Camel-Case',
+                'path' => '/headers/camel-case'
+            ],
+        ];
+    }
+}

--- a/tests/TestApp/Controllers/HeadersController.php
+++ b/tests/TestApp/Controllers/HeadersController.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace willitscale\StreetlampTests\TestApp\Controllers;
+
+use Psr\Http\Message\ResponseInterface;
+use willitscale\Streetlamp\Attributes\Controller\RouteController;
+use willitscale\Streetlamp\Attributes\Parameter\HeaderParameter;
+use willitscale\Streetlamp\Attributes\Path;
+use willitscale\Streetlamp\Attributes\Route\Method;
+use willitscale\Streetlamp\Builders\ResponseBuilder;
+use willitscale\Streetlamp\Enums\HttpMethod;
+use willitscale\Streetlamp\Enums\HttpStatusCode;
+
+#[RouteController]
+#[Path('/headers')]
+class HeadersController
+{
+    #[Path('/lower-case')]
+    #[Method(HttpMethod::GET)]
+    public function headersLowerCase(
+        #[HeaderParameter('lower-case', true)] string $header,
+    ): ResponseInterface {
+        return new ResponseBuilder()
+            ->setData($header)
+            ->setHttpStatusCode(HttpStatusCode::HTTP_OK)
+            ->build();
+    }
+
+    #[Path('/upper-case')]
+    #[Method(HttpMethod::GET)]
+    public function headersUpperCase(
+        #[HeaderParameter('UPPER-CASE', true)] string $header,
+    ): ResponseInterface {
+        return new ResponseBuilder()
+            ->setData($header)
+            ->setHttpStatusCode(HttpStatusCode::HTTP_OK)
+            ->build();
+    }
+
+    #[Path('/mixed-case')]
+    #[Method(HttpMethod::GET)]
+    public function headersMixedCase(
+        #[HeaderParameter('mIxEd-CaSe', true)] string $header,
+    ): ResponseInterface {
+        return new ResponseBuilder()
+            ->setData($header)
+            ->setHttpStatusCode(HttpStatusCode::HTTP_OK)
+            ->build();
+    }
+
+    #[Path('/camel-case')]
+    #[Method(HttpMethod::GET)]
+    public function headersCamelCase(
+        #[HeaderParameter('Camel-Case', true)] string $header,
+    ): ResponseInterface {
+        return new ResponseBuilder()
+            ->setData($header)
+            ->setHttpStatusCode(HttpStatusCode::HTTP_OK)
+            ->build();
+    }
+}


### PR DESCRIPTION
Header keys not aligning with https://www.rfc-editor.org/rfc/rfc9110.html#name-field-names