### PR TITLE
Headers not setting correctly with last fix

### DIFF
--- a/src/Requests/ServerRequest.php
+++ b/src/Requests/ServerRequest.php
@@ -58,7 +58,7 @@ class ServerRequest implements ServerRequestInterface
         $headers = [];
         foreach ($_SERVER as $name => $value) {
             if (0 === stripos($name, 'HTTP_')) {
-                $key = substr($name, 5);
+                $key = strtolower(substr($name, 5));
                 $headers[$key] = [$value];
             }
         }


### PR DESCRIPTION
Didn't account for _SERVER setting headers in the tests, need to circle back round on the tests for this.