### PR TITLE
Type-o fix

### DIFF
--- a/src/Requests/ServerRequest.php
+++ b/src/Requests/ServerRequest.php
@@ -58,7 +58,7 @@ class ServerRequest implements ServerRequestInterface
         $headers = [];
         foreach ($_SERVER as $name => $value) {
             if (0 === stripos($name, 'HTTP_')) {
-                $key = str_replace('_', ' ', strtolower(substr($name, 5)));
+                $key = str_replace('_', '-', strtolower(substr($name, 5)));
                 $headers[$key] = [$value];
             }
         }


### PR DESCRIPTION
Replaced underscores with spaces instead of dashes.