### PR TITLE
Fix empty values invalid

### DIFF
--- a/src/Attributes/DataBindings/Json/JsonArray.php
+++ b/src/Attributes/DataBindings/Json/JsonArray.php
@@ -32,7 +32,7 @@ class JsonArray implements ArrayMapInterface, JsonAttribute
     {
         $key = (empty($this->alias)) ? $property->getName() : $this->alias;
 
-        if ($this->required && empty($jsonValue->{$key})) {
+        if ($this->required && !isset($jsonValue->{$key})) {
             $className = get_class($instance);
             throw new InvalidParameterTypeException(
                 "JS001",

--- a/src/Attributes/DataBindings/Json/JsonProperty.php
+++ b/src/Attributes/DataBindings/Json/JsonProperty.php
@@ -30,7 +30,7 @@ readonly class JsonProperty implements JsonAttribute
     {
         $key = (empty($this->alias)) ? $property->getName() : $this->alias;
 
-        if ($this->required && empty($jsonValue->{$key})) {
+        if ($this->required && !isset($jsonValue->{$key})) {
             $className = get_class($instance);
             throw new InvalidParameterTypeException(
                 "JS001",


### PR DESCRIPTION
If passing 0, an empty string or empty array the parameter will fail.